### PR TITLE
Add /trade endpoint

### DIFF
--- a/app/controllers/api/v1/trade_controller.rb
+++ b/app/controllers/api/v1/trade_controller.rb
@@ -1,0 +1,71 @@
+module Api::V1
+  class TradeController < ApiController
+    before_action :set_traders, only: [:index]
+
+    def_param_group :trade do
+      param :survivor, Hash, :required => true, :desc => 'Survivor' do
+        param :id, :number, :required => true
+        param :offer, Hash, :required => true do
+          param_group :items, SurvivorsController
+        end
+      end
+      param :recipient, Hash, :required => true, :desc => 'Trade Recipient' do
+        param :id, :number, :required => true
+        param :offer, Hash, :required => true do
+          param_group :items, SurvivorsController
+        end
+      end
+    end
+
+    api :POST, '/trade'
+    param_group :trade
+    def index
+      unless @survivor and @recipient
+        return render json: { error: 'Invalid Traders' }, status: 403
+      end
+
+      if @survivor.infected? or @recipient.infected?
+        return render json: { error: 'Infected survivors are not allowed to trade' }, status: 403
+      end
+
+      survivor_offer  = params[:survivor][:offer]
+      recipient_offer = params[:recipient][:offer]
+
+      offer_score = { survivor: 0, recipient: 0 }
+
+      ITEMS.each do |item, item_score|
+        offer_score[:survivor]  += item_score * survivor_offer[item].to_i
+        offer_score[:recipient] += item_score * recipient_offer[item].to_i
+
+        balance = survivor_offer[item].to_i - recipient_offer[item].to_i
+        if balance.positive?
+          @recipient[item] -= balance
+          @survivor[item]  += balance
+        elsif balance.negative?
+          @recipient[item] += balance
+          @survivor[item]  -= balance
+        end
+      end
+
+      if offer_score[:survivor].eql? offer_score[:recipient]
+        @survivor.save!
+        @recipient.save!
+      else
+        return render json: { error: 'Trade offers do not have the same score' }, status: 403
+      end
+
+      head 204
+    end
+
+    private
+      def set_traders
+        @survivor  = Survivor.find(params[:survivor][:id])
+        @recipient = Survivor.find(params[:recipient][:id])
+      end
+
+      def trade_params
+        params.require(:survivor).permit(:id, :offer => [:water, :food, :medication, :ammo])
+        params.require(:recipient).permit(:id, :offer => [:water, :food, :medication, :ammo])
+      end
+  end
+end

--- a/config/initializers/custom_constants.rb
+++ b/config/initializers/custom_constants.rb
@@ -1,0 +1,1 @@
+ITEMS = { water: 4, food: 3, medication: 2, ammo: 1 }.freeze

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :survivors, except: [:destroy]
       post 'report_infection', to: 'survivors#report_infection', as: 'report_infection'
+      post :trade, to: 'trade#index', as: 'trade'
     end
   end
 end

--- a/spec/controllers/api/v1/survivors_controller_spec.rb
+++ b/spec/controllers/api/v1/survivors_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Api::V1::SurvivorsController, :type => :api do
+describe Api::V1::SurvivorsController, type: :api do
   let!(:survivor) { create(:survivor) }
 
   context '#create' do

--- a/spec/controllers/api/v1/trade_controller_spec.rb
+++ b/spec/controllers/api/v1/trade_controller_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::TradeController, type: :api do
+  let!(:infected) { create(:survivor, infected: true) }
+  let!(:survivor) { create(:survivor) }
+  let!(:trader)   { create(:survivor, :with_items) }
+
+  describe "#index" do
+    let(:offer_items) { { water: 0, food: 0, medication: 0, ammo: 0 } }
+    let(:trade_params) do
+      {
+        survivor:  { id: survivor.id, offer: offer_items.merge(medication: 2) },
+        recipient: { id: trader.id, offer: offer_items.merge(water: 1) }
+      }
+    end
+
+    context 'when trade is valid' do
+      subject { post '/api/v1/trade', trade_params }
+      it { expect(subject.status).to be(204) }
+    end
+
+    context 'when trade offers have different scores' do
+      let(:invalid_score_params) { trade_params.merge(survivor: { id: survivor.id, offer: offer_items }) }
+      subject { post '/api/v1/trade', invalid_score_params }
+      it { expect(subject.status).to be(403) }
+    end
+
+    context 'when a trader is infected' do
+      let(:infected_trade_params) { trade_params.merge(survivor: { id: infected.id, offer: offer_items.merge(medication: 2) }) }
+      subject { post '/api/v1/trade', infected_trade_params }
+      it { expect(subject.status).to be(403) }
+    end
+
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     s.sequence(:name) {|n| "Survivor #{n}"}
 
     trait :with_items do
-      after(:build) do |object|
+      after(:create) do |object|
         object.update!(water: 1, food: 2, medication: 3, ammo: 4)
       end
     end


### PR DESCRIPTION
Survivors can trade among themselves respecting an items scoreboard
so it makes trades fair. Infected survivors are not allowed to trade.