### PR TITLE
Fix /survivors docs and removes #destroy

### DIFF
--- a/app/controllers/api/v1/survivors_controller.rb
+++ b/app/controllers/api/v1/survivors_controller.rb
@@ -2,40 +2,43 @@ module Api::V1
   class SurvivorsController < ApiController
     before_action :set_survivor, only: [:show, :update, :destroy]
 
-    def_param_group :location do
-      param :lat, Float, 'Latitude'
-      param :lng, Float, 'Longitude'
+    def_param_group :location_apipie do
+      param :survivor, Hash, :required => true do
+        param :lat, :number, 'Latitude', :required => true
+        param :lng, :number, 'Longitude', :required => true
+      end
     end
 
-    def_param_group :items do
+    def_param_group :items_apipie do
       param :water, :number, 'Water'
       param :food, :number, 'Food'
       param :medication, :number, 'Medication'
       param :ammo, :number, 'Ammunition'
     end
 
-    def_param_group :survivor do
-      param :id, :number
-      param :name, String
+    def_param_group :survivor_apipie do
+      param :name, String, :required => true
       param :age, :number
-      param_group :location
-      param_group :items
+      param :lat, :number, 'Latitude'
+      param :lng, :number, 'Longitude'
+      param_group :items_apipie
     end
 
-    api :GET, '/survivors'
+    api :GET, '/survivors', 'List survivors'
+    param :page, :number
     def index
       survivors = Survivor.page(params[:page]).per(12)
       render json: survivors, meta: {pagination: {per_page: 12}}
     end
 
-    api :GET, '/survivors/:id'
+    api :GET, '/survivors/:id', 'Get a single survivor'
     param :id, :number
     def show
       render json: @survivor
     end
 
-    api :POST, '/survivors'
-    param_group :survivor, required: true
+    api :POST, '/survivors', 'Create a new survivor'
+    param_group :survivor_apipie, :required => true
     def create
       @survivor = Survivor.new(survivor_params)
 
@@ -46,8 +49,9 @@ module Api::V1
       end
     end
 
-    api :PATCH, '/survivors/:id'
-    api :PUT, '/survivors/:id'
+    api :PATCH, '/survivors/:id', 'Update survivor location'
+    api :PUT, '/survivors/:id', 'Update survivor location'
+    param_group :location_apipie
     param :id, :number, required: true
     def update
       @survivor = Survivor.find(params[:id])
@@ -58,13 +62,6 @@ module Api::V1
       end
     end
 
-    # DELETE /survivors/1
-    api :DELETE, '/survivors/:id'
-    param :id, :number, required: true
-    def destroy
-      @survivor.destroy
-    end
-
     private
       # Use callbacks to share common setup or constraints between actions.
       def set_survivor
@@ -72,7 +69,8 @@ module Api::V1
       end
 
       def location_params
-        params.require(:survivor).permit(:lat, :lng)
+        params.require(:survivor)
+        params.require(:survivor => [:lat, :lng])
       end
 
       # Only allow a trusted parameter "white list" through.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   root to: redirect('/apipie')
   namespace :api do
     namespace :v1 do
-      resources :survivors
+      resources :survivors, except: [:destroy]
     end
   end
 end


### PR DESCRIPTION
- A description was added to each action under `/survivors`.
- #destroy action was removed to not allow survivors to be deleted anymore.